### PR TITLE
プレイヤーのジャンプ調整、爆発物の時間経過処理追加

### DIFF
--- a/TeamProjectProto/Assets/PrototypeLevel/Field.prefab
+++ b/TeamProjectProto/Assets/PrototypeLevel/Field.prefab
@@ -24,7 +24,7 @@ GameObject:
   - component: {fileID: 23860960822539474}
   m_Layer: 0
   m_Name: StageWall4
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -42,7 +42,7 @@ GameObject:
   - component: {fileID: 23685311703704054}
   m_Layer: 0
   m_Name: LowWall8 (28)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -60,7 +60,7 @@ GameObject:
   - component: {fileID: 23076658940465538}
   m_Layer: 0
   m_Name: LowWall8 (1)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -78,7 +78,7 @@ GameObject:
   - component: {fileID: 23592216423102344}
   m_Layer: 0
   m_Name: StageWall2
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -96,7 +96,7 @@ GameObject:
   - component: {fileID: 23425468880078864}
   m_Layer: 0
   m_Name: Wall (15)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -114,7 +114,7 @@ GameObject:
   - component: {fileID: 23002308629016112}
   m_Layer: 0
   m_Name: Wall (7)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -132,7 +132,7 @@ GameObject:
   - component: {fileID: 23095419694347412}
   m_Layer: 0
   m_Name: Wall (21)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -150,7 +150,7 @@ GameObject:
   - component: {fileID: 23509003910990964}
   m_Layer: 0
   m_Name: LowWall8 (29)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -168,7 +168,7 @@ GameObject:
   - component: {fileID: 23883057585752302}
   m_Layer: 0
   m_Name: LowWall8 (21)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -186,7 +186,7 @@ GameObject:
   - component: {fileID: 23434548497056662}
   m_Layer: 0
   m_Name: LowWall8 (37)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -204,7 +204,7 @@ GameObject:
   - component: {fileID: 23716872303092066}
   m_Layer: 0
   m_Name: LowWall8 (8)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -222,7 +222,7 @@ GameObject:
   - component: {fileID: 23482584608463366}
   m_Layer: 0
   m_Name: LowWall8 (9)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -240,7 +240,7 @@ GameObject:
   - component: {fileID: 23989230074815268}
   m_Layer: 0
   m_Name: Wall (4)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -258,7 +258,7 @@ GameObject:
   - component: {fileID: 23411188385053506}
   m_Layer: 0
   m_Name: LowWall8 (45)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -276,7 +276,7 @@ GameObject:
   - component: {fileID: 23656443773042246}
   m_Layer: 0
   m_Name: LowWall8 (41)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -294,7 +294,7 @@ GameObject:
   - component: {fileID: 23541317454177256}
   m_Layer: 0
   m_Name: LowWall8 (31)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -312,7 +312,7 @@ GameObject:
   - component: {fileID: 23458070517498778}
   m_Layer: 0
   m_Name: Wall (19)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -330,7 +330,7 @@ GameObject:
   - component: {fileID: 23825896539649804}
   m_Layer: 0
   m_Name: HeighWall5 (5)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -348,7 +348,7 @@ GameObject:
   - component: {fileID: 23716251736186406}
   m_Layer: 0
   m_Name: LowWall8 (7)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -366,7 +366,7 @@ GameObject:
   - component: {fileID: 23662946440176906}
   m_Layer: 0
   m_Name: LowWall8 (40)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -384,7 +384,7 @@ GameObject:
   - component: {fileID: 23916467247498068}
   m_Layer: 0
   m_Name: LowWall8 (36)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -402,7 +402,7 @@ GameObject:
   - component: {fileID: 23782131838221480}
   m_Layer: 0
   m_Name: LowWall8 (22)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -420,7 +420,7 @@ GameObject:
   - component: {fileID: 23368329299069608}
   m_Layer: 0
   m_Name: Wall
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -438,7 +438,7 @@ GameObject:
   - component: {fileID: 23038914293532172}
   m_Layer: 0
   m_Name: LowWall8 (23)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -456,7 +456,7 @@ GameObject:
   - component: {fileID: 23259512277332506}
   m_Layer: 0
   m_Name: LowWall8 (3)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -474,7 +474,7 @@ GameObject:
   - component: {fileID: 23944034158702872}
   m_Layer: 0
   m_Name: LowWall8 (25)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -492,7 +492,7 @@ GameObject:
   - component: {fileID: 23399253084290822}
   m_Layer: 0
   m_Name: Wall (22)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -510,7 +510,7 @@ GameObject:
   - component: {fileID: 23258228050938498}
   m_Layer: 0
   m_Name: Wall (10)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -528,7 +528,7 @@ GameObject:
   - component: {fileID: 23044064859444534}
   m_Layer: 0
   m_Name: LowWall8 (26)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -546,7 +546,7 @@ GameObject:
   - component: {fileID: 23116585719449414}
   m_Layer: 0
   m_Name: HeighWall5 (7)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -564,7 +564,7 @@ GameObject:
   - component: {fileID: 23975643752612848}
   m_Layer: 0
   m_Name: Wall (13)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -582,7 +582,7 @@ GameObject:
   - component: {fileID: 23948716044139174}
   m_Layer: 0
   m_Name: LowWall8 (34)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -600,7 +600,7 @@ GameObject:
   - component: {fileID: 23337323423225022}
   m_Layer: 0
   m_Name: LowWall8 (47)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -618,7 +618,7 @@ GameObject:
   - component: {fileID: 23249764985091394}
   m_Layer: 0
   m_Name: LowWall8 (13)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -636,7 +636,7 @@ GameObject:
   - component: {fileID: 23862213981979720}
   m_Layer: 0
   m_Name: Wall (8)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -654,7 +654,7 @@ GameObject:
   - component: {fileID: 23118689008811324}
   m_Layer: 0
   m_Name: LowWall8 (16)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -672,7 +672,7 @@ GameObject:
   - component: {fileID: 23521655376634118}
   m_Layer: 0
   m_Name: LowWall7
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -690,7 +690,7 @@ GameObject:
   - component: {fileID: 23714695844739130}
   m_Layer: 0
   m_Name: LowWall8 (27)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -708,7 +708,7 @@ GameObject:
   - component: {fileID: 23677289448846528}
   m_Layer: 0
   m_Name: LowWall8 (43)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -726,7 +726,7 @@ GameObject:
   - component: {fileID: 23881199933740782}
   m_Layer: 0
   m_Name: HeighWall5 (6)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -744,7 +744,7 @@ GameObject:
   - component: {fileID: 23736215166171950}
   m_Layer: 0
   m_Name: LowWall8 (30)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -762,7 +762,7 @@ GameObject:
   - component: {fileID: 23268826363268058}
   m_Layer: 0
   m_Name: StageWall1
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -780,7 +780,7 @@ GameObject:
   - component: {fileID: 23057030976800554}
   m_Layer: 0
   m_Name: Wall (5)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -798,7 +798,7 @@ GameObject:
   - component: {fileID: 23867199043602276}
   m_Layer: 0
   m_Name: LowWall8 (12)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -816,7 +816,7 @@ GameObject:
   - component: {fileID: 23760576853171052}
   m_Layer: 0
   m_Name: LowWall8 (19)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -834,7 +834,7 @@ GameObject:
   - component: {fileID: 23942433500995130}
   m_Layer: 0
   m_Name: Wall (17)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -852,7 +852,7 @@ GameObject:
   - component: {fileID: 23235878045900140}
   m_Layer: 0
   m_Name: LowWall8 (38)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -870,7 +870,7 @@ GameObject:
   - component: {fileID: 23206325521086528}
   m_Layer: 0
   m_Name: HeighWall5 (4)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -888,7 +888,7 @@ GameObject:
   - component: {fileID: 23334645540300286}
   m_Layer: 0
   m_Name: LowWall8 (42)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -906,7 +906,7 @@ GameObject:
   - component: {fileID: 23099300232834322}
   m_Layer: 0
   m_Name: Wall (1)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -924,7 +924,7 @@ GameObject:
   - component: {fileID: 23839169054420084}
   m_Layer: 0
   m_Name: StageWall3
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -942,7 +942,7 @@ GameObject:
   - component: {fileID: 23010070090701982}
   m_Layer: 0
   m_Name: Wall (20)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -960,7 +960,7 @@ GameObject:
   - component: {fileID: 23161647436048260}
   m_Layer: 0
   m_Name: Wall (16)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -978,7 +978,7 @@ GameObject:
   - component: {fileID: 23805703983667048}
   m_Layer: 0
   m_Name: LowWall8 (17)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -996,7 +996,7 @@ GameObject:
   - component: {fileID: 23166818649349290}
   m_Layer: 0
   m_Name: LowWall8 (15)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1014,7 +1014,7 @@ GameObject:
   - component: {fileID: 23048369374769190}
   m_Layer: 0
   m_Name: LowWall8 (20)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1032,7 +1032,7 @@ GameObject:
   - component: {fileID: 23924742283148494}
   m_Layer: 0
   m_Name: LowWall8 (10)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1050,7 +1050,7 @@ GameObject:
   - component: {fileID: 23116627152393818}
   m_Layer: 0
   m_Name: LowWall8 (14)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1068,7 +1068,7 @@ GameObject:
   - component: {fileID: 23975034875311814}
   m_Layer: 0
   m_Name: Wall (2)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1086,7 +1086,7 @@ GameObject:
   - component: {fileID: 23668502536494736}
   m_Layer: 0
   m_Name: HeighWall5 (1)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1104,7 +1104,7 @@ GameObject:
   - component: {fileID: 23449794006314586}
   m_Layer: 0
   m_Name: LowWall8 (32)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1122,7 +1122,7 @@ GameObject:
   - component: {fileID: 23291436051937890}
   m_Layer: 0
   m_Name: Wall (23)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1140,7 +1140,7 @@ GameObject:
   - component: {fileID: 23819921404562428}
   m_Layer: 0
   m_Name: Wall (12)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1158,7 +1158,7 @@ GameObject:
   - component: {fileID: 23594258767451928}
   m_Layer: 0
   m_Name: Wall (14)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1191,7 +1191,7 @@ GameObject:
   - component: {fileID: 23613769755260328}
   m_Layer: 0
   m_Name: LowWall8 (2)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1209,7 +1209,7 @@ GameObject:
   - component: {fileID: 23079412591420000}
   m_Layer: 0
   m_Name: LowWall8 (5)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1227,7 +1227,7 @@ GameObject:
   - component: {fileID: 23203730556182308}
   m_Layer: 0
   m_Name: Wall (3)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1245,7 +1245,7 @@ GameObject:
   - component: {fileID: 23282932145907328}
   m_Layer: 0
   m_Name: Wall (18)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1263,7 +1263,7 @@ GameObject:
   - component: {fileID: 23079212004654868}
   m_Layer: 0
   m_Name: Wall (9)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1281,7 +1281,7 @@ GameObject:
   - component: {fileID: 23921514866818014}
   m_Layer: 0
   m_Name: HeighWall5 (8)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1299,7 +1299,7 @@ GameObject:
   - component: {fileID: 23462373316061688}
   m_Layer: 0
   m_Name: LowWall8 (35)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1317,7 +1317,7 @@ GameObject:
   - component: {fileID: 23712239609302932}
   m_Layer: 0
   m_Name: LowWall8 (46)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1335,7 +1335,7 @@ GameObject:
   - component: {fileID: 23209789506052564}
   m_Layer: 0
   m_Name: LowWall8 (6)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1353,7 +1353,7 @@ GameObject:
   - component: {fileID: 23411229182133812}
   m_Layer: 0
   m_Name: LowWall8 (18)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1371,7 +1371,7 @@ GameObject:
   - component: {fileID: 23861684626106994}
   m_Layer: 0
   m_Name: HeighWall5 (2)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1389,7 +1389,7 @@ GameObject:
   - component: {fileID: 23864141220323706}
   m_Layer: 0
   m_Name: HeighWall5 (3)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1407,7 +1407,7 @@ GameObject:
   - component: {fileID: 23183755494580126}
   m_Layer: 0
   m_Name: LowWall8 (24)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1425,7 +1425,7 @@ GameObject:
   - component: {fileID: 23713037729305000}
   m_Layer: 0
   m_Name: LowWall8 (48)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1443,7 +1443,7 @@ GameObject:
   - component: {fileID: 23496511149206808}
   m_Layer: 0
   m_Name: LowWall8 (44)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1461,7 +1461,7 @@ GameObject:
   - component: {fileID: 23132795924941468}
   m_Layer: 0
   m_Name: LowWall8 (33)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1479,7 +1479,7 @@ GameObject:
   - component: {fileID: 23466257539696486}
   m_Layer: 0
   m_Name: LowWall8 (4)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1497,7 +1497,7 @@ GameObject:
   - component: {fileID: 23341852714971170}
   m_Layer: 0
   m_Name: LowWall8 (39)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1515,7 +1515,7 @@ GameObject:
   - component: {fileID: 23515758338430706}
   m_Layer: 0
   m_Name: LowWall8 (11)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1533,7 +1533,7 @@ GameObject:
   - component: {fileID: 23908443435494212}
   m_Layer: 0
   m_Name: Wall (11)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1551,7 +1551,7 @@ GameObject:
   - component: {fileID: 23516406079951328}
   m_Layer: 0
   m_Name: LowWall8 (49)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1569,7 +1569,7 @@ GameObject:
   - component: {fileID: 23318082549289320}
   m_Layer: 0
   m_Name: Floor
-  m_TagString: Floor
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1587,7 +1587,7 @@ GameObject:
   - component: {fileID: 23092345637797798}
   m_Layer: 0
   m_Name: Wall (6)
-  m_TagString: Wall
+  m_TagString: Field
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/TeamProjectProto/Assets/Scene/main.unity
+++ b/TeamProjectProto/Assets/Scene/main.unity
@@ -513,6 +513,10 @@ Prefab:
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
+    - target: {fileID: 1616616915032062, guid: 86055f8fac1ef024db132f095580d231, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 86055f8fac1ef024db132f095580d231, type: 2}
   m_IsPrefabParent: 0
@@ -630,6 +634,10 @@ Prefab:
       value: 
       objectReference: {fileID: 1813721638279764, guid: fe6d91baf678ead44a1d53e2cf35aaa4,
         type: 2}
+    - target: {fileID: 1683142682674056, guid: 42484bd1175e7554ba7a04d10e2c40d1, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 42484bd1175e7554ba7a04d10e2c40d1, type: 2}
   m_IsPrefabParent: 0
@@ -809,6 +817,10 @@ Prefab:
     - target: {fileID: 4674833337504830, guid: 2b11a4b20aa30694ea6865569e0d99d8, type: 2}
       propertyPath: m_RootOrder
       value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 1760102373035588, guid: 2b11a4b20aa30694ea6865569e0d99d8, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 2b11a4b20aa30694ea6865569e0d99d8, type: 2}
@@ -1049,6 +1061,10 @@ Prefab:
     - target: {fileID: 1595179670168276, guid: 98545818b6fa6d4418f2500bc2a23996, type: 2}
       propertyPath: m_TagString
       value: Field
+      objectReference: {fileID: 0}
+    - target: {fileID: 1428004748631768, guid: 98545818b6fa6d4418f2500bc2a23996, type: 2}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 98545818b6fa6d4418f2500bc2a23996, type: 2}

--- a/TeamProjectProto/Assets/Script/BalloonController.cs
+++ b/TeamProjectProto/Assets/Script/BalloonController.cs
@@ -39,6 +39,10 @@ public class BalloonController : MonoBehaviour {
 
     BalloonState balloonState;//爆発物の状態
 
+    public bool isTimeBlast = false;//時間経過で爆破の切り替え
+    public float originBlastTime = 1.0f;//爆発物が膨らむ間隔
+    float blastTime;
+
 	// Use this for initialization
 	void Start () {
         //初期化処理
@@ -49,6 +53,8 @@ public class BalloonController : MonoBehaviour {
         balloonState = BalloonState.SAFETY;
         scaleRate = scaleLimit / blastLimit;
         blastCount = 0;
+        isTimeBlast = false;
+        blastTime = originBlastTime;
 
         player = GameObject.Find("Player" + Random.Range(1, 5));//プレイヤーをランダムで指定
         player.GetComponent<PlayerMove>().balloon = transform.gameObject;//プレイヤー内に自分を指定
@@ -60,6 +66,14 @@ public class BalloonController : MonoBehaviour {
         if(Input.GetKeyDown(KeyCode.A))
         {
             BalloonBlast();
+        }
+
+        //時間経過で膨らむ処理
+        blastTime -= Time.deltaTime;
+        if(blastTime <= 0)
+        {
+            BalloonBlast();
+            blastTime = originBlastTime;
         }
 
         //プレイヤーについていなければ


### PR DESCRIPTION
PlayerMove.cs
List<GameObject> onObject:新規作成
 今当たっているオブジェクト
isTimeblast:新規作成
 時間経過で爆破の切り替え
originBlastTime:新規作成
blastTime:新規作成
Start()
 onObjectの初期化処理
 isTimeBlastの初期化処理
 blastTimeの初期化処理
Update()
 時間経過でblastCount増加
WallSide():新規作成
 壁の横にいる処理
OnCollisionEnter()
 フィールドに当たった際の処理を修正
OnCollisionExit()
 フィールドから離れた際の処理を修正

PrototypeLevel
Field
 タグ変更