### PR TITLE
リザルトシーンのシーン移行バグ解消

### DIFF
--- a/TeamProjectProto/Assets/Scene/Result.unity
+++ b/TeamProjectProto/Assets/Scene/Result.unity
@@ -282,7 +282,7 @@ MonoBehaviour:
   zDistance: 20
   oneMoreBtn: {fileID: 128662108}
   toTitleBtn: {fileID: 783692505}
-  textMovingTime: 1.5
+  textMovingTime: 1
 --- !u!4 &130474216
 Transform:
   m_ObjectHideFlags: 0

--- a/TeamProjectProto/Assets/Scene/StageSelect.unity
+++ b/TeamProjectProto/Assets/Scene/StageSelect.unity
@@ -635,7 +635,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1220915093
 RectTransform:
   m_ObjectHideFlags: 0

--- a/TeamProjectProto/Assets/Script/Result/ResultManager.cs
+++ b/TeamProjectProto/Assets/Script/Result/ResultManager.cs
@@ -36,7 +36,7 @@ public class ResultManager : SceneController
 
     //Anim
     [SerializeField]
-    float textMovingTime = 2f;//順位テキストの移動スピード
+    float textMovingTime;//順位テキストの移動スピード
     List<Vector2> finishPosition = new List<Vector2>();//最終位置
     List<GameObject> playerScoreTexts = new List<GameObject>();//プレイヤースコア表示テキスト
 
@@ -71,6 +71,11 @@ public class ResultManager : SceneController
 
         switch (sceneState)
         {
+            case ResultSceneState.FadeIn://フェードイン中
+                if (fadeController.IsFadeInFinish)
+                    sceneState = ResultSceneState.RankAnim;
+                break;
+
             case ResultSceneState.RankAnim://アニメ中
                 StartCoroutine(ShowRankCoroutine());
                 break;
@@ -163,16 +168,24 @@ public class ResultManager : SceneController
     {
         yield return new WaitForSeconds(0.5f);
 
+        //ランキング表示アニメ
         for (int i = 0; i < _playerRankTextsList.Count; i++)
         {
             _playerRankTextsList[i].rectTransform.DOAnchorPos(finishPosition[i], textMovingTime);
+
+            //最下位のアニメーションの終わる時間に合わせて
+            if (i == _playerRankTextsList.Count - 1)
+            {
+                yield return new WaitForSeconds(textMovingTime - 0.5f);
+            }
             yield return new WaitForSeconds(0.5f);
         }
         //アニメ終わったらoneMore選択
         oneMoreBtn.Select();
         nowSelectedBtn = oneMoreBtn;
-
-        sceneState = ResultSceneState.None;
+        //SceneState移行
+        if(sceneState == ResultSceneState.RankAnim)
+            sceneState = ResultSceneState.None;
     }
 
     /// <summary>

--- a/TeamProjectProto/Assets/Script/SceneController.cs
+++ b/TeamProjectProto/Assets/Script/SceneController.cs
@@ -93,6 +93,7 @@ public class SceneController : MonoBehaviour
     /// </summary>
     public enum ResultSceneState
     {
+        FadeIn,     //フェードイン中
         RankAnim,   //アニメ中
         None,       //基準状態
         ToNextScene //次のシーンに移行


### PR DESCRIPTION
修正
SceneController.csー＞ResultSceneStateにFadeIn追加
ResultManager.csー＞FadeIn完了後Animが実行、NoneStateにするコードを一回しか呼ばばいように変更
Result.unityー＞textMovingTime: 1.5＞＞1
StageSelect.unityー＞最初から左矢印出ないように